### PR TITLE
Fixes hardcoded generations on for cycle

### DIFF
--- a/src/com/nickbenn/advent/day17/ConwayCubes.java
+++ b/src/com/nickbenn/advent/day17/ConwayCubes.java
@@ -76,7 +76,7 @@ public class ConwayCubes {
     Set<Cell> population = cells.stream()
         .map((cell) -> new Cell(cell, dimensions))
         .collect(Collectors.toCollection(() -> new TreeSet<>(REVERSE_DIMENSION_COMPARATOR)));
-    for (int i = 0; i < 6; i++) {
+    for (int i = 0; i < generations; i++) {
       iterate(population);
     }
     return population.size();


### PR DESCRIPTION
The function countActive considered a parameter for the number of cycles (generations). However, the value 6 was hard-coded in the main for loop.